### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/lib/src/igdb_client.dart
+++ b/lib/src/igdb_client.dart
@@ -50,7 +50,7 @@ class IGDBClient {
     }
 
     var resp = await request.close();
-    var responseBody = await resp.transform(utf8.decoder).join();
+    var responseBody = await resp.cast<List<int>>().transform(utf8.decoder).join();
     
     var error = null;
     var data = null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: igdb_client
 description: A dart library for IGDB API
-version: 0.0.4
+version: 0.0.4+1
 homepage: https://github.com/mitchhymel/dart-igdb_client
 author: Mitch Hymel <mitchell.hymel@gmail.com>
 


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900